### PR TITLE
May 2025 Sanoid post: Fix value and duplication on recursive setting

### DIFF
--- a/zfs-automatic-snapshots-with-sanoid-on-freebsd/sanoid_autosnap.yml
+++ b/zfs-automatic-snapshots-with-sanoid-on-freebsd/sanoid_autosnap.yml
@@ -24,7 +24,7 @@
         block: |
           [{{ poolname.stdout }}]
             use_template = {{ poolname.stdout }}
-            recursive = zfs
+            recursive = yes
 
           #############################
           # templates below this line #
@@ -33,7 +33,6 @@
             hourly = 36
             daily = 14
             monthly = 6
-            recursive = yes
             autosnap = yes
             autoprune = yes
             frequent_period = 15


### PR DESCRIPTION
Thank you for your work promoting FreeBSD.

I noticed this in the provided Ansible playbook after reading the blog post, where `recursive` is set twice, at the template and dataset level, one of them to the value `zfs`.

As far as I can tell from the [Sanoid documentation](https://github.com/jimsalterjrs/sanoid/wiki/Sanoid#options), this value should be either `yes` or `no`, and it can not be used in templates.

Note that the blog post also contain a similar error, where `recursive = yes` is also [presented at the template level](https://freebsdfoundation.org/blog/zfs-automatic-snapshots-with-sanoid-on-freebsd#:~:text=recursive%20%3D%20yes).